### PR TITLE
Language.mode.options.added

### DIFF
--- a/src/main/java/org/primefaces/extensions/optimizerplugin/model/ResourcesSet.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/model/ResourcesSet.java
@@ -90,6 +90,13 @@ public class ResourcesSet {
      */
     private String languageIn;
 
+    /**
+     * Configuration for output JS language mode.
+     *
+     * @parameter
+     */
+    private String languageOut;
+
     public File getInputDir() {
         return inputDir;
     }
@@ -160,5 +167,13 @@ public class ResourcesSet {
 
     public void setLanguageIn(String languageIn) {
         this.languageIn = languageIn;
+    }
+
+    public String getLanguageOut() {
+        return languageOut;
+    }
+
+    public void setLanguageOut(String languageOut) {
+        this.languageOut = languageOut;
     }
 }

--- a/src/main/java/org/primefaces/extensions/optimizerplugin/model/ResourcesSet.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/model/ResourcesSet.java
@@ -83,6 +83,13 @@ public class ResourcesSet {
      */
     private SourceMap sourceMap;
 
+    /**
+     * Configuration for input JS language mode.
+     *
+     * @parameter
+     */
+    private String languageIn;
+
     public File getInputDir() {
         return inputDir;
     }
@@ -145,5 +152,13 @@ public class ResourcesSet {
 
     public void setSourceMap(SourceMap sourceMap) {
         this.sourceMap = sourceMap;
+    }
+
+    public String getLanguageIn() {
+        return languageIn;
+    }
+
+    public void setLanguageIn(String languageIn) {
+        this.languageIn = languageIn;
     }
 }

--- a/src/main/java/org/primefaces/extensions/optimizerplugin/optimizer/ClosureCompilerOptimizer.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/optimizer/ClosureCompilerOptimizer.java
@@ -71,6 +71,9 @@ public class ClosureCompilerOptimizer extends AbstractOptimizer {
 
         LanguageMode langIn = rsa.getLanguageIn();
         options.setLanguageIn(langIn);
+
+        LanguageMode langOut = rsa.getLanguageOut();
+        options.setLanguageOut(langOut);
         Compiler.setLoggingLevel(Level.WARNING);
 
         try {

--- a/src/main/java/org/primefaces/extensions/optimizerplugin/optimizer/ClosureCompilerOptimizer.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/optimizer/ClosureCompilerOptimizer.java
@@ -23,6 +23,7 @@ import com.google.common.io.Files;
 import com.google.javascript.jscomp.CompilationLevel;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.JSError;
 import com.google.javascript.jscomp.Result;
 import com.google.javascript.jscomp.SourceFile;
@@ -67,6 +68,9 @@ public class ClosureCompilerOptimizer extends AbstractOptimizer {
 
         WarningLevel warnLevel = rsa.getWarningLevel();
         warnLevel.setOptionsForWarningLevel(options);
+
+        LanguageMode langIn = rsa.getLanguageIn();
+        options.setLanguageIn(langIn);
         Compiler.setLoggingLevel(Level.WARNING);
 
         try {

--- a/src/main/java/org/primefaces/extensions/optimizerplugin/util/ResourcesSetJsAdapter.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/util/ResourcesSetJsAdapter.java
@@ -19,7 +19,6 @@
 package org.primefaces.extensions.optimizerplugin.util;
 
 import com.google.javascript.jscomp.CompilationLevel;
-import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.WarningLevel;
 import org.primefaces.extensions.optimizerplugin.model.Aggregation;
@@ -43,14 +42,17 @@ public class ResourcesSetJsAdapter extends ResourcesSetAdapter {
 
     private LanguageMode languageIn;
 
+    private LanguageMode languageOut;
+
     public ResourcesSetJsAdapter(File inputDir, Set<File> files, Aggregation aggregation, CompilationLevel compilationLevel,
                                  WarningLevel warningLevel, SourceMap sourceMap, String encoding, boolean failOnWarning,
-                                 String suffix, LanguageMode languageIn) {
+                                 String suffix, LanguageMode languageIn, LanguageMode languageOut) {
         super(inputDir, files, aggregation, encoding, failOnWarning, suffix);
         this.compilationLevel = compilationLevel;
         this.warningLevel = warningLevel;
         this.sourceMap = sourceMap;
         this.languageIn = languageIn;
+        this.languageOut = languageOut;
     }
 
     public CompilationLevel getCompilationLevel() {
@@ -67,5 +69,9 @@ public class ResourcesSetJsAdapter extends ResourcesSetAdapter {
 
     public LanguageMode getLanguageIn() {
         return languageIn;
+    }
+
+    public LanguageMode getLanguageOut() {
+        return languageOut;
     }
 }

--- a/src/main/java/org/primefaces/extensions/optimizerplugin/util/ResourcesSetJsAdapter.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/util/ResourcesSetJsAdapter.java
@@ -19,6 +19,8 @@
 package org.primefaces.extensions.optimizerplugin.util;
 
 import com.google.javascript.jscomp.CompilationLevel;
+import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.WarningLevel;
 import org.primefaces.extensions.optimizerplugin.model.Aggregation;
 import org.primefaces.extensions.optimizerplugin.model.SourceMap;
@@ -39,13 +41,16 @@ public class ResourcesSetJsAdapter extends ResourcesSetAdapter {
 
     private SourceMap sourceMap;
 
+    private LanguageMode languageIn;
+
     public ResourcesSetJsAdapter(File inputDir, Set<File> files, Aggregation aggregation, CompilationLevel compilationLevel,
                                  WarningLevel warningLevel, SourceMap sourceMap, String encoding, boolean failOnWarning,
-                                 String suffix) {
+                                 String suffix, LanguageMode languageIn) {
         super(inputDir, files, aggregation, encoding, failOnWarning, suffix);
         this.compilationLevel = compilationLevel;
         this.warningLevel = warningLevel;
         this.sourceMap = sourceMap;
+        this.languageIn = languageIn;
     }
 
     public CompilationLevel getCompilationLevel() {
@@ -58,5 +63,9 @@ public class ResourcesSetJsAdapter extends ResourcesSetAdapter {
 
     public SourceMap getSourceMap() {
         return sourceMap;
+    }
+
+    public LanguageMode getLanguageIn() {
+        return languageIn;
     }
 }


### PR DESCRIPTION
Two new tags added:
languageIn and languageOut
It allows to set google compiler options for input and output JS language specifications.

Default value for languageIn in console runner of compiler is ECMPSCRIPT6, but in API (CompilerOptions class) it is ECMPSCRIPT3, so I can't compile JS sources with string countinuations symbols ('\' instead of '+').

Now plugin support language specifications option.

It would be very good if possible to make small release (ex. 2.0.1) with this feature.

Thank you! 