### PR TITLE
Bug with imagesDir default value was fixed.

### DIFF
--- a/src/main/java/org/primefaces/extensions/optimizerplugin/ResourcesOptimizerMojo.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/ResourcesOptimizerMojo.java
@@ -64,9 +64,7 @@ public class ResourcesOptimizerMojo extends AbstractMojo {
     /**
      * Images directories according to JSF spec.
      *
-     * @parameter default-value="${project.basedir}${file.separator}src${file.separator}main${file.separator}webapp${file
-     * .separator}resources,${project.basedir}${file.separator}src${file.separator}main${file.separator}resources${file
-     * .separator}META-INF${file.separator}resources"
+     * @parameter default-value="${project.basedir}${file.separator}src${file.separator}main${file.separator}webapp${file.separator}resources, ${project.basedir}${file.separator}src${file.separator}main${file.separator}resources${file.separator}META-INF${file.separator}resources"
      */
     private String imagesDir;
 


### PR DESCRIPTION
When by default imagesDir was initialised with 3 strings, the compiler takes only first string.

So, we should to use only one string in definition of default values at mojo class.

What do you think?