### PR TITLE
Now it checks if path is not the same when moving sourcemaps files.

### DIFF
--- a/src/main/java/org/primefaces/extensions/optimizerplugin/optimizer/ClosureCompilerOptimizer.java
+++ b/src/main/java/org/primefaces/extensions/optimizerplugin/optimizer/ClosureCompilerOptimizer.java
@@ -314,8 +314,10 @@ public class ClosureCompilerOptimizer extends AbstractOptimizer {
             String name = file.getName();
             String target = outputDir + name;
             File targetFile = new File(target);
-            Files.createParentDirs(targetFile);
-            Files.move(file, targetFile);
+            if(!file.equals(targetFile)) {
+                Files.createParentDirs(targetFile);
+                Files.move(file, targetFile);
+            }
         } catch (Exception e) {
             log.error("File " + file + " could not be moved to " + outputDir, e);
         }


### PR DESCRIPTION
It was an exception when it tries to move file to the same directory.